### PR TITLE
upgrade intl 0.19.0 dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   freezed_annotation: ^2.2.0
   infinite_scroll_pagination: ^3.2.0
-  intl: ^0.18.0
+  intl: ^0.19.0
   json_annotation: ^4.8.0
   logger: ^2.0.1
   path: ^1.8.2


### PR DESCRIPTION
Solve dependency problem:
Because flutter_movies_app depends on flutter_localizations from sdk which depends on intl 0.19.0, intl 0.19.0 is required. So, because flutter_movies_app depends on intl ^0.18.0, version solving failed.